### PR TITLE
Simplify Title Tag on Index Page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
-<title>{{site.author.name}}{% if page.title %} | {{page.title}}{% endif %}</title>
+<title>{{site.author.name}}{% if page.title and page.url != "/" and page.url != "/index.html" %} | {{page.title}}{% endif %}</title>
 <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
 <link rel="shortcut icon" type="image/png" href="{{ "/assets/img/favicon.png" | relative_url }}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
The title tag doesn't need to include front matter on the index page.