### PR TITLE
Remove Title Tag Added By jekyll-seo-tag Plugin

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,4 +3,4 @@
 <link rel="shortcut icon" type="image/png" href="{{ "/assets/img/favicon.png" | relative_url }}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="UTF-8">
-{% seo %}
+{% seo title=false %}


### PR DESCRIPTION
The head.html include file specifies the ideal title tag, but the SEO
plugin, by default, will also add one. Alter the head.html include to
not add an extra title tag.