### PR TITLE
Revert to Default Skin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ show_excerpts: true
 # Custom theme settings. Specify the specific skin or syntax
 # highlighting here.
 oceanic:
-  skin: black
+  skin: default
   code-skin: default
 
   # If you wish to have a photo or logo in the header, specify the


### PR DESCRIPTION
Accidentally committed _config.yml with a custom skin specified. Should
be "default", with the option to allow users to change it.