### PR TITLE
Get Site Subtitle From Tagline Setting

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -28,11 +28,11 @@ name of the company for a company site. It is configured like this:
 
 The author setting is used by the template as the site title.
 
-### Description Setting
+### Tagline Setting
 
-The description is the value given to the site's sub-title:
+The tagline is the value given to the site's sub-title:
 
-    description: >
+    Tagline: >
       A man of many talents, with relationships, experiences, and human
       emotions
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,9 @@ theme: jekyll-oceanic
 author:
   name: "Oceanic"
 
-# A description of you, or of the site. This is displayed in the header.
-description: A minimalist, blue, Jekyll theme.
+# A short description (e.g., A blog dedicated to reviewing cat gifs) of your
+# site.
+tagline: A minimalist, blue, Jekyll theme.
 
 # Show the first openings of posts when listing. Set to false to just
 # display titles and dates.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
     <div class="header-text-wrap">
       <div class="header-text">
         <h1>{{ site.author.name }}</h1>
-        <h2>{{ site.description }}</h2>
+        <h2>{{ site.tagline }}</h2>
       </div>
     </div>
   </div>


### PR DESCRIPTION
`description` is for a longer description of the site. `tagline` is more
appropriate.