### PR TITLE
Fix Blog Pagination Showing Too Few Posts

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -4,7 +4,6 @@ title: Blog
 pagegroup: __blog
 pagination:
   enabled: true
-  per_page: 2
 nav:
   enabled: true
 ---


### PR DESCRIPTION
An errant setting in the front matter of /blog/index.html is causing
only two blog posts to be shown per page.